### PR TITLE
Update the Mock LDAP usage guidelines + Allow logins for Alice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,10 @@ image :
 	docker build -t ${IMAGENAME} .
 
 run :
-	docker run -P --rm -i -t ${IMAGENAME}
+	docker run -P -p 389:389 --rm -i -t ${IMAGENAME}
+
+setup-ldap:
+	ldapadd -h localhost -p 389 -c -x -D cn=admin,dc=jenkins-ci,dc=org -f data.ldif -w s3cr3t
 
 tag :
 	docker tag ${IMAGENAME} ${IMAGENAME}:${TAG}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,24 @@
-## Test LDAP Container
+# Test LDAP Container
+
 [![Build Status](http://ci.jenkins-ci.org/buildStatus/icon?job=infra_mock-ldap)](http://ci.jenkins-ci.org/view/Infrastructure/job/infra_mock-ldap/)
 
 This container runs OpenLDAP, like `ldap.jenkins-ci.org`, except that it uses bogus test data instead
-of real production data. This is useful as a test fixture.
+of real production data.
+This is useful as a test fixture.
+It can be also used for testing of the [Jenkins Account App](https://github.com/jenkins-infra/account-app).
 
 Two users 'kohsuke' and 'alice' exist in this database. 'kohsuke' is an admin and 'alice' is a regular user. Passwords for both users are 'password'.
+
+## Usage
+
+1. `make build`
+2. `make run`
+3. Open a second terminal, run `make setup-ldap` there
+
+After that the LDAP instance will be available on port 389.
+It can be accessed with the following master credentials:
+
+```conf
+managerDN=cn=admin,dc=jenkins-ci,dc=org
+managerPassword=s3cr3t
+```

--- a/data.ldif
+++ b/data.ldif
@@ -55,5 +55,6 @@ objectClass: inetOrgPerson
 cn: alice
 mail: bob@jenkins-ci.org
 givenName: Alice
+employeeNumber: alice
 sn: Ashley
 userPassword: {SSHA}yI6cZwQadOA1e+/f+T+H3eCQQhRzYWx0


### PR DESCRIPTION
Just a small patch I applied to make it easier to use Mock LDAP for testing of the Jenkins Account App.

CC @timja @olblak 
